### PR TITLE
feat: autoclose sidebar when menu item is clicked in mobile view.

### DIFF
--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -91,12 +91,18 @@ const data = {
  * @returns {React.ReactNode} 应用侧边栏组件
  */
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
-  const { toggleSidebar, state } = useSidebar()
+  const { toggleSidebar, state, isMobile, setOpenMobile } = useSidebar()
   const { user, getTrustLevelLabel, logout } = useUser()
   const [showLogoutDialog, setShowLogoutDialog] = React.useState(false)
   const [isLoggingOut, setIsLoggingOut] = React.useState(false)
   const pathname = usePathname()
   const router = useRouter()
+
+  const handleCloseSidebar = React.useCallback(() => {
+    if (isMobile) {
+      setOpenMobile(false)
+    }
+  }, [isMobile, setOpenMobile])
 
   const handleLogout = async () => {
     setIsLoggingOut(true)
@@ -179,16 +185,25 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   </span>
                 </div>
               </DropdownMenuLabel>
-              <DropdownMenuItem onClick={() => router.push("/settings/profile")}>
+              <DropdownMenuItem onClick={() => {
+                router.push("/settings/profile")
+                handleCloseSidebar()
+              }}>
                 <UserRound className="mr-2 size-4" />
                 <span>我的资料</span>
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => router.push("/settings")}>
+              <DropdownMenuItem onClick={() => {
+                router.push("/settings")
+                handleCloseSidebar()
+              }}>
                 <Settings className="mr-2 size-4" />
                 <span>设置</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator className="my-2" />
-              <DropdownMenuItem onClick={() => router.push("/docs/how-to-use")}>
+              <DropdownMenuItem onClick={() => {
+                router.push("/docs/how-to-use")
+                handleCloseSidebar()
+              }}>
                 <FileQuestionMark className="mr-2 size-4" />
                 <span>使用帮助</span>
               </DropdownMenuItem>
@@ -210,7 +225,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       isActive={pathname === item.url}
                       asChild
                     >
-                      <Link href={item.url}>
+                      <Link href={item.url} onClick={handleCloseSidebar}>
                         {item.icon && <item.icon />}
                         <span>{item.title}</span>
                       </Link>
@@ -235,7 +250,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                         isActive={pathname === item.url}
                         asChild
                       >
-                        <Link href={item.url}>
+                        <Link href={item.url} onClick={handleCloseSidebar}>
                           {item.icon && <item.icon />}
                           <span>{item.title}</span>
                         </Link>
@@ -259,7 +274,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       tooltip={item.title}
                       asChild
                     >
-                      <Link href={item.url} target="_blank" rel="noopener noreferrer">
+                      <Link href={item.url} target="_blank" rel="noopener noreferrer" onClick={handleCloseSidebar}>
                         {item.icon && <item.icon />}
                         <span>{item.title}</span>
                       </Link>
@@ -282,7 +297,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       tooltip={item.title}
                       asChild
                     >
-                      <Link href={item.url}>
+                      <Link href={item.url} onClick={handleCloseSidebar}>
                         {item.icon && <item.icon />}
                         <span>{item.title}</span>
                       </Link>


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并


**变更内容**

在isMobile状态下，点击侧边栏的menu_item时，自动隐藏侧边栏。

**变更原因**

优化用户体验，现在点击`首页、集市、积分、活动、在线流转`切换时需要手动点击侧边外阴影区域隐藏，而`接口文档、使用文档`点击时由于跳转新页面，侧边栏会自动收起。此commit添加了自动隐藏侧边栏功能，使其保持一致。