### PR TITLE
feat: add time gitter to the retry logic to avoid intensive requests

### DIFF
--- a/internal/apps/user/tasks.go
+++ b/internal/apps/user/tasks.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/hibiken/asynq"
@@ -95,6 +96,9 @@ func HandleUpdateSingleUserGamificationScore(ctx context.Context, t *asynq.Task)
 	response, errGet := user.GetUserGamificationScore(ctx)
 	if errGet != nil {
 		logger.ErrorF(ctx, "处理用户[%s]失败: %v", user.Username, errGet)
+		// 添加随机延迟(1-60秒)防止重试时请求积聚
+		jitter := time.Duration(1+rand.Intn(60)) * time.Second
+		time.Sleep(jitter)
 		return errGet
 	}
 


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**变更内容**

本PR在`task.go`里面加入了1-60s的随机延迟，然后将失败请求置入重试队列，打散了重试请求的间隔，尽可能避免集中请求的发生。

**变更原因**

原先`user.go`文件里面使用了golang自身默认的指数退避逻辑`asynq.MaxRetry(5)`，但是由于429会在一起出现，所以这些失败的请求在1、2、4、8、16分钟后会被集中再次发出，导致再次集中触发429。