### PR TITLE
feat: change some tooltip to popover to fit mobile view

### DIFF
--- a/frontend/components/common/home/data-panel.tsx
+++ b/frontend/components/common/home/data-panel.tsx
@@ -3,7 +3,7 @@ import { Area, AreaChart, XAxis } from "recharts"
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { CountingNumber } from '@/components/animate-ui/primitives/texts/counting-number'
 import { Skeleton } from "@/components/ui/skeleton"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Info } from "lucide-react"
 
 import { useUser } from "@/contexts/user-context"
@@ -190,16 +190,14 @@ export function DataPanel() {
         <div className="flex-1 md:pt-4 pl-0 md:pl-0">
           <div className="text-sm text-muted-foreground font-medium flex items-center gap-1 whitespace-nowrap">
             今日剩余额度
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <Info className="size-3.5" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>每日积分消耗额度限制，每日 0 点自动重置</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Popover>
+              <PopoverTrigger>
+                <Info className="size-3.5 cursor-pointer" />
+              </PopoverTrigger>
+              <PopoverContent side="top" className="w-auto max-w-[280px] p-3">
+                <p className="text-xs">每日积分消耗额度限制，每日 0 点自动重置</p>
+              </PopoverContent>
+            </Popover>
           </div>
           <div className="text-xl font-semibold pt-2">
             {userLoading ? '-' : remainQuota < 0 ? "无限制" : <CountingNumber number={remainQuota} decimalPlaces={2} />}

--- a/frontend/components/common/settings/profile.tsx
+++ b/frontend/components/common/settings/profile.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious, type CarouselApi } from "@/components/ui/carousel"
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Info } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -408,16 +408,14 @@ export function ProfileMain() {
               <div className="space-y-1">
                 <div className="text-xs text-muted-foreground flex items-center gap-1">
                   社区积分
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="h-3 w-3 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-[280px] text-center">
-                        <p className="text-xs">上一次从社区同步的积分，积分会在每日划转时通过系统定时任务自动同步更新</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <Popover>
+                    <PopoverTrigger>
+                      <Info className="h-3 w-3 cursor-help" />
+                    </PopoverTrigger>
+                    <PopoverContent side="top" className="w-auto max-w-[280px] p-3">
+                      <p className="text-xs">上一次从社区同步的积分，积分会在每日划转时通过系统定时任务自动同步更新</p>
+                    </PopoverContent>
+                  </Popover>
                 </div>
                 <div className="text-sm font-medium tabular-nums">
                   {parseFloat(user.community_balance).toLocaleString()}

--- a/frontend/components/ui/popover.tsx
+++ b/frontend/components/ui/popover.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-progress':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
**例行检查**  

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**变更内容**

将`/home`中的`今日剩余额度`和`/settings/profile`中`社区积分`右侧的Info组件，由Tooltip改为Popover。

<img width="443" height="543" alt="image" src="https://github.com/user-attachments/assets/cc95ea02-634e-457c-9d41-c1764a19b8c6" />


**变更原因**

radix-ui的tooltip仅支持在PC端hover时显示内容(See [Issue](https://github.com/radix-ui/primitives/issues/955#issuecomment-960610209))；而在手机浏览器中，hover事件并不能触发，导致内容完全无法显示。

本Commit将其转为popover组件，即可适配手机端点击展开事件。