### PR TITLE
feat: scroll to current level card on profile page

### DIFF
--- a/frontend/components/common/settings/profile.tsx
+++ b/frontend/components/common/settings/profile.tsx
@@ -276,7 +276,7 @@ export function ProfileMain() {
     return () => {
       api.off("reInit", scrollToCurrentLevel)
     }
-  }, [api, currentLevel.level, levelConfigs])
+  }, [api, currentLevel, levelConfigs])
 
   if (loading) {
     return (


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并


**变更内容**

修改了个人资料界面会员等级卡片显示。

**变更原因**

现在可以默认定位到用户当前等级的卡片，而不是默认的初始级别。
![post](https://github.com/user-attachments/assets/0d0a5c4b-d32a-4ca2-bf06-95bb46c161be)
