### PR TITLE
fix: cancel in security options does not work

### DIFF
--- a/frontend/components/common/settings/security.tsx
+++ b/frontend/components/common/settings/security.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
@@ -58,8 +59,10 @@ export function SecurityMain() {
     }
   }
 
+  const router = useRouter()
+
   const handleCancel = () => {
-    form.reset()
+    router.push("/settings")
   }
 
   return (


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并



**变更内容**

更改了安全设置下"取消"键相关逻辑。
<!-- 请在下方简要描述此 PR 的变更内容 -->

**变更原因**

此按键能像预期一样退回上一页，而不是仅清空表单。
![PixPin_2025-12-30_13-48-56](https://github.com/user-attachments/assets/ef1822e6-3615-4007-89d4-acce4fa6a3fc)
