### PR TITLE
fix: preview on online-paying page missing transition

### DIFF
--- a/frontend/components/common/merchant/merchant-online.tsx
+++ b/frontend/components/common/merchant/merchant-online.tsx
@@ -584,8 +584,8 @@ function MerchantOnlineContent({ apiKeys }: MerchantOnlineContentProps) {
                       )}
                     </AnimatePresence>
 
-                    <div className={`h-full w-full overflow-y-auto custom-scrollbar flex items-center justify-center p-4 ${ previewTheme === 'dark' ? 'dark bg-zinc-900' : 'bg-white' }`}>
-                      <div className={`flex ${ previewDevice === 'mobile' ? 'flex-col' : 'flex-row' } w-full max-w-4xl backdrop-blur-2xl border rounded-3xl overflow-hidden shadow-2xl relative shrink-0 ${ previewTheme === 'dark' ? 'bg-card/70 border-border/50' : 'bg-white border-gray-200' }`}>
+                    <div className={`h-full w-full overflow-y-auto custom-scrollbar flex items-center justify-center p-4 transition-colors duration-500 ${ previewTheme === 'dark' ? 'dark bg-zinc-900' : 'bg-white' }`}>
+                      <div className={`flex ${ previewDevice === 'mobile' ? 'flex-col' : 'flex-row' } w-full max-w-4xl backdrop-blur-2xl border rounded-3xl overflow-hidden shadow-2xl relative shrink-0 transition-colors duration-500 ${ previewTheme === 'dark' ? 'bg-card/70 border-border/50' : 'bg-white border-gray-200' }`}>
                         <PayingInfo orderInfo={previewOrderInfo} loading={loading} forceMobile={previewDevice === 'mobile'} />
                         <PayingNow orderInfo={previewOrderInfo} paying={false} payKey="" currentStep="method" selectedMethod="alipay" isOpen={false} loading={false} onPayKeyChange={() => { }} onCurrentStepChange={() => { }} onSelectedMethodChange={() => { }} onIsOpenChange={() => { }} onPayOrder={() => { }} forceMobile={previewDevice === 'mobile'} />
                         <div className="absolute inset-0 z-50 bg-transparent cursor-default" />

--- a/frontend/components/common/pay/paying/paying-now.tsx
+++ b/frontend/components/common/pay/paying/paying-now.tsx
@@ -433,7 +433,7 @@ export function PayingNow({
   }
 
   return (
-    <div className={`flex-1 flex flex-col items-center justify-center p-6 relative overflow-hidden bg-white dark:bg-neutral-900 ${ forceMobile ? '' : 'md:p-8' }`}>
+    <div className={`flex-1 flex flex-col items-center justify-center p-6 relative overflow-hidden bg-white dark:bg-neutral-900 transition-colors duration-500 ${ forceMobile ? '' : 'md:p-8' }`}>
       <div className="w-full relative z-10 flex flex-col h-full justify-center">
         <div className="flex-1 flex flex-col justify-center">
           {renderContent()}


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并




**变更内容**

修改在线流转界面的实时浏览动画。

**变更原因**


切换亮色-暗色模式时，外部组件缺少对应动画。
|前|后|
|:-|-:|
|![pre](https://github.com/user-attachments/assets/1ae09fe4-4f3f-416e-b4a6-8c7cc3f72cff)|![post](https://github.com/user-attachments/assets/77122d8d-d420-4b60-9628-d0e9388c9aa8)|
