### PR TITLE
fix: 主页开发者部分修正

### DIFF
--- a/frontend/components/home/developer-section.tsx
+++ b/frontend/components/home/developer-section.tsx
@@ -36,8 +36,8 @@ export const DeveloperSection = React.memo(function DeveloperSection({ className
           transition={{ duration: 0.8 }}
           className="order-2 lg:order-1 relative"
         >
-          <div className="relative overflow-hidden rounded-xl border border-white/20 bg-black backdrop-blur-xl shadow-2xl">
-            <div className="flex items-center px-4 py-3 border-b border-white/20">
+          <div className="relative overflow-hidden rounded-xl border border-white/20 bg-black backdrop-blur-xl shadow-2xl max-w-full">
+            <div className="flex items-center px-4 py-3 border-b border-white/20 w-full">
               <div className="flex-1 flex gap-2">
                 <div className="w-3 h-3 rounded-full bg-[#ff5f56]" />
                 <div className="w-3 h-3 rounded-full bg-[#ffbd2e]" />
@@ -56,7 +56,7 @@ export const DeveloperSection = React.memo(function DeveloperSection({ className
                   {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
                 </Button>
               </div>
-              <pre className="text-sm font-mono text-neutral-300 leading-relaxed">
+              <pre className="text-xs sm:text-sm font-mono text-neutral-300 leading-relaxed whitespace-pre-wrap break-all sm:whitespace-pre sm:break-normal overflow-x-auto">
                 <code className="block">
                   <span className="text-purple-400">curl</span> <span className="text-green-400">https://credit.linux.do/epay/submit.php</span> \{'\n'}
                   {'  '}-u <span className="text-yellow-400">sk_live_...:</span> \{'\n'}


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**变更内容**

主页Developer部分。

**变更原因**

1. `bash`未居中。
![post](https://github.com/user-attachments/assets/de760f24-4f75-4163-99bc-01daeaa263d1)
2. 背景缺少pulse效果。
![post](https://github.com/user-attachments/assets/e8954b22-d581-4744-a882-ed82a0f32083)
3. 移动设备下终端栏过宽

|前|后|
|:-|-:|
|<img width="1003" height="685" alt="image" src="https://github.com/user-attachments/assets/6cdffd7c-5c31-47ab-8c09-cece1bc8e11b" />|<img width="1080" height="659" alt="image" src="https://github.com/user-attachments/assets/69b0ced1-c09d-4d1a-a063-826f90600a62" />|


