### PR TITLE
feat: add a upright arrow icon to the new-paged link

### DIFF
--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -57,6 +57,7 @@ import {
   Globe,
   Layers,
   Trophy,
+  ArrowUpRight,
 } from "lucide-react"
 
 import { useUser } from "@/contexts/user-context"
@@ -324,7 +325,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     >
                       <Link href={item.url} target="_blank" rel="noopener noreferrer" onClick={handleCloseSidebar}>
                         {item.icon && <item.icon />}
-                        <span>{item.title}</span>
+                        <span className="flex-1">{item.title}</span>
+                        <ArrowUpRight className="size-3 text-muted-foreground" />
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**变更内容**

在接口文档、使用文档等需要在新页面中打开的链接的按钮右侧添加"↗" icon

| 前 | 后 |
|----|----|
| <img width="272" height="154" alt="image" src="https://github.com/user-attachments/assets/a7c77fee-caed-4b55-8c90-8e79999fc2ee" /> | <img width="287" height="172" alt="image" src="https://github.com/user-attachments/assets/388d8702-d2e8-4aa4-a694-105eb47b1e78" /> |

**变更原因**

好看，而且可以让用户直观知道点击这个按钮会跳转到其他页面 w