### PR TITLE
fix(theme): 主题模式明暗自动切换显示逻辑问题

### DIFF
--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -22,7 +22,7 @@ import { SearchDialog } from "@/components/layout/search-dialog"
  */
 export function SiteHeader({ isFullWidth = false, onToggleFullWidth }: { isFullWidth?: boolean, onToggleFullWidth?: (value: boolean) => void }) {
   const { user } = useUser()
-  const { theme, setTheme } = useTheme()
+  const { setTheme, resolvedTheme } = useTheme()
   const router = useRouter()
   const [mounted, setMounted] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
@@ -93,8 +93,8 @@ export function SiteHeader({ isFullWidth = false, onToggleFullWidth }: { isFullW
               <span className="sr-only">切换全宽</span>
             </Button>
 
-            <Button variant="ghost" size="icon" className="size-9 text-muted-foreground hover:text-foreground" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
-              {mounted ? (theme === 'dark' ? <Sun className="size-[18px]" /> : <Moon className="size-[18px]" />) : <Moon className="size-[18px]" />}
+            <Button variant="ghost" size="icon" className="size-9 text-muted-foreground hover:text-foreground" onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}>
+              {mounted ? (resolvedTheme === 'dark' ? <Sun className="size-[18px]" /> : <Moon className="size-[18px]" />) : <Moon className="size-[18px]" />}
               <span className="sr-only">主题切换</span>
             </Button>
           </div>


### PR DESCRIPTION
**例行检查**  

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**关联信息**

| 用户设置   | theme 值  | 系统偏好 | 实际显示 | 应该显示 | 是否正确 |
|--------|----------|------|------|------|------|
| light  | "light"  | -    | Moon | Moon | ✓    |
| dark   | "dark"   | -    | Sun  | Sun  | ✓    |
| system | "system" | 浅色   | Moon | Moon | ✓    |
| system | "system" | 深色   | Moon | Sun  | ✗    |


**变更内容**

使用 ```resolvedTheme``` 代替 ```theme``` 进行判断

**变更原因**

```resolvedTheme``` 能拿到实际解析后的主题值