### PR TITLE
fix: reset filter not working properly

### DIFF
--- a/frontend/components/common/general/table-filter.tsx
+++ b/frontend/components/common/general/table-filter.tsx
@@ -198,7 +198,11 @@ export function TableFilter({
   }
 
   /* 是否有激活的筛选 */
-  const hasActiveFilters = selectedTypes.length > 0 || selectedStatuses.length > 0 || selectedTimeRange !== null || Object.values(searchValues).some(v => v)
+  const hasActiveFilters = 
+    (enabledFilters.type && selectedTypes.length > 0) || 
+    (enabledFilters.status && selectedStatuses.length > 0) || 
+    (enabledFilters.timeRange && selectedTimeRange !== null) || 
+    (enabledFilters.search && Object.values(searchValues || {}).some(v => v))
 
   return (
     <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">

--- a/frontend/components/common/merchant/merchant-data.tsx
+++ b/frontend/components/common/merchant/merchant-data.tsx
@@ -9,6 +9,7 @@ import { TableFilter, type SearchValues } from "@/components/common/general/tabl
 import { TransactionTableList } from "@/components/common/general/table-data"
 import type { MerchantAPIKey, OrderType, OrderStatus } from "@/lib/services"
 import { TransactionProvider, useTransaction } from "@/contexts/transaction-context"
+import { formatLocalDate } from "@/lib/utils"
 
 /** 集市功能列表 */
 const MERCHANT_ACTIONS = [
@@ -17,16 +18,6 @@ const MERCHANT_ACTIONS = [
   { title: "在线流转", description: "创建在线积分流转活动", icon: Link2, color: "text-purple-600", bgColor: "bg-purple-50 dark:bg-purple-950/20", action: "online-payment" as const },
 ]
 
-/** 格式化日期为本地时间字符串 */
-const formatLocalDate = (date: Date) => {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  const h = String(date.getHours()).padStart(2, '0')
-  const min = String(date.getMinutes()).padStart(2, '0')
-  const s = String(date.getSeconds()).padStart(2, '0')
-  return `${ y }-${ m }-${ d }T${ h }:${ min }:${ s }+08:00`
-}
 
 /** 获取默认日期范围（最近30天） */
 const getDefaultDateRange = () => {
@@ -46,12 +37,7 @@ interface MerchantDataProps {
  * 显示应用的活动数据和统计信息
  */
 export function MerchantData({ apiKey }: MerchantDataProps) {
-  const start = new Date()
-  start.setHours(0, 0, 0, 0)
-  start.setDate(start.getDate() - 29)
-  const end = new Date()
-  end.setHours(0, 0, 0, 0)
-  end.setDate(end.getDate() + 1)
+  const { from: start, to: end } = getDefaultDateRange()
 
   return (
     <TransactionProvider
@@ -97,6 +83,7 @@ function MerchantDataContent({ apiKey }: MerchantDataProps) {
       startTime: dateRange ? formatLocalDate(dateRange.from) : undefined,
       endTime: dateRange ? (() => {
         const endDate = new Date(dateRange.to)
+        endDate.setHours(0, 0, 0, 0)
         endDate.setDate(endDate.getDate() + 1)
         return formatLocalDate(endDate)
       })() : undefined,

--- a/frontend/components/common/trade/trade-table.tsx
+++ b/frontend/components/common/trade/trade-table.tsx
@@ -69,15 +69,6 @@ function TransactionList({ initialType }: { initialType?: OrderType }) {
     setDateRange(null)
     setSelectedQuickSelection(null)
     setSelectedSearch({})
-
-    /* 重新获取数据 */
-    fetchTransactions({
-      page: 1,
-      page_size: pageSize,
-      type: initialType,
-      startTime: undefined,
-      endTime: undefined,
-    })
   }
 
   /* 当筛选条件改变时，重新加载数据 */


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并



<!-- 若以上均没有，请删除此节 -->

**变更内容**

修复「清空筛选」时会自动弹回「最近1个月」
![image](https://github.com/user-attachments/assets/846918b8-6838-4600-9949-e970dbeff50b)

同步两个table组件的行为

**变更原因**

代码逻辑中存在「所有时间」为设置项时隐藏「清空筛选」，而且这样也更符合直觉


