### PR TITLE
FIX: /trade page error when list contains red envelope refund records

### DIFF
--- a/frontend/components/common/general/table-filter.tsx
+++ b/frontend/components/common/general/table-filter.tsx
@@ -21,7 +21,8 @@ export const typeConfig: Record<OrderType, { label: string; color: string }> = {
   distribute: { label: '商户分发', color: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300' },
   test: { label: '应用测试', color: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300 font-bold' },
   red_envelope_send: { label: '红包支出', color: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300' },
-  red_envelope_receive: { label: '红包收入', color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300' }
+  red_envelope_receive: { label: '红包收入', color: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300' },
+  red_envelope_refund: { label: '红包退款', color: 'bg-muted/50 text-gray-800 dark:bg-gray-900 dark:text-gray-300' }
 }
 
 /* 状态标签配置 */

--- a/frontend/components/common/trade/trade-main.tsx
+++ b/frontend/components/common/trade/trade-main.tsx
@@ -51,6 +51,7 @@ const PAGE_COMPONENTS: Record<TabValue, React.ComponentType> = {
   test: () => null,
   red_envelope_send: RedEnvelope,
   red_envelope_receive: RedEnvelope,
+  red_envelope_refund: RedEnvelope,
   redenvelope: RedEnvelope,
   all: AllActivity,
 }

--- a/frontend/lib/services/transaction/types.ts
+++ b/frontend/lib/services/transaction/types.ts
@@ -1,7 +1,7 @@
 /**
  * 订单类型
  */
-export type OrderType = 'receive' | 'payment' | 'transfer' | 'community' | 'online' | 'test' | 'distribute' | 'red_envelope_send' | 'red_envelope_receive';
+export type OrderType = 'receive' | 'payment' | 'transfer' | 'community' | 'online' | 'test' | 'distribute' | 'red_envelope_send' | 'red_envelope_receive' | 'red_envelope_refund';
 
 /**
  * 订单状态


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**关联信息**

/t/-/1441587

**变更内容**

修复记录查询页面含有“红包退款”记录时，页面报错的问题。

**变更原因**

bug修复，补充“红包退款”的Tag颜色定义，确保页面正常显示。