### PR TITLE
Set receive tab as default on redenvelope page.

### DIFF
--- a/frontend/components/common/trade/red-envelope.tsx
+++ b/frontend/components/common/trade/red-envelope.tsx
@@ -402,7 +402,7 @@ export function RedEnvelopeList({ refreshTrigger }: { refreshTrigger?: number })
         { value: 'sent', label: '我发出的', color: 'bg-primary/10 text-primary' },
         { value: 'received', label: '我收到的', color: 'bg-primary/10 text-primary' }
       ]}
-      defaultTab="sent"
+      defaultTab="received"
       refreshTrigger={refreshTrigger}
     />
   )


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并


<!-- 若以上均没有，请删除此节 -->

**变更内容**
Set receive tab as default on redenvelope page.


**变更原因**
