### PR TITLE
fix: red envelope refund should not show credit transfer field

### DIFF
--- a/frontend/components/common/general/table-data.tsx
+++ b/frontend/components/common/general/table-data.tsx
@@ -162,7 +162,7 @@ const TransactionTableRow = React.memo(React.forwardRef<HTMLTableRowElement, {
         </Badge>
       </TableCell>
       <TableCell className="text-[11px] font-medium whitespace-nowrap text-center py-1">
-        {order.status === 'pending' || order.status === 'expired' || order.type === 'community' || order.type === 'red_envelope_send' ? (
+        {order.status === 'pending' || order.status === 'expired' || order.type === 'community' || order.type === 'red_envelope_send' || order.type === 'red_envelope_refund' ? (
           <div className="text-muted-foreground">-</div>
         ) : (
           <TooltipProvider>


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**关联信息**

#163 
<!-- 若以上均没有，请删除此节 -->

**变更内容**

display `- ` for type `red_envelope_refund`
