### PR TITLE
fix: merchant distribution encounter 404 using web portal

### DIFF
--- a/frontend/components/common/merchant/merchant-distribute.tsx
+++ b/frontend/components/common/merchant/merchant-distribute.tsx
@@ -19,18 +19,20 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Spinner } from "@/components/ui/spinner"
-import { MerchantService } from "@/lib/services"
+import { MerchantService, type MerchantAPIKey } from "@/lib/services"
 
 interface DistributeDialogProps {
   /** 自定义触发器 */
   trigger?: React.ReactNode
+  /** 商户凭证 */
+  apiKey?: Pick<MerchantAPIKey, "client_id" | "client_secret">
 }
 
 /**
  * 商户分发对话框
  * 商户向用户分发积分
  */
-export function DistributeDialog({ trigger }: DistributeDialogProps) {
+export function DistributeDialog({ trigger, apiKey }: DistributeDialogProps) {
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
 
@@ -88,11 +90,19 @@ export function DistributeDialog({ trigger }: DistributeDialogProps) {
     try {
       setLoading(true)
 
+      if (!apiKey?.client_id || !apiKey?.client_secret) {
+        toast.error('缺少应用凭证', { description: '请先创建应用并确认凭证可用' })
+        return
+      }
+
       const result = await MerchantService.distribute({
-        user_id: userId.trim(),
+        user_id: Number(userId.trim()),
         username: username.trim(),
         amount: amountNum,
         remark: remark.trim() || undefined,
+      }, {
+        client_id: apiKey.client_id,
+        client_secret: apiKey.client_secret,
       })
 
       toast.success('分发成功', {

--- a/frontend/components/common/merchant/merchant-info.tsx
+++ b/frontend/components/common/merchant/merchant-info.tsx
@@ -221,7 +221,7 @@ export function MerchantInfo({ apiKey, onUpdate, onDelete, updateAPIKey }: Merch
             }
           />
 
-          <DistributeDialog />
+          <DistributeDialog apiKey={apiKey} />
 
           <AlertDialog>
             <AlertDialogTrigger asChild>

--- a/frontend/lib/services/core/base.service.ts
+++ b/frontend/lib/services/core/base.service.ts
@@ -170,6 +170,7 @@ export class BaseService {
    * @template T - 响应数据类型
    * @param url - 完整 URL
    * @param data - 请求数据
+   * @param config - 额外的请求配置
    * @returns 响应数据（不经过 response.data.data 解包）
    * 
    * @remarks
@@ -178,8 +179,9 @@ export class BaseService {
   protected static async rawPost<T>(
     url: string,
     data?: unknown,
+    config?: InternalAxiosRequestConfig,
   ): Promise<T> {
-    const response = await apiClient.post<T>(url, data);
+    const response = await apiClient.post<T>(url, data, config);
     return response.data;
   }
 }

--- a/frontend/lib/services/merchant/merchant.service.ts
+++ b/frontend/lib/services/merchant/merchant.service.ts
@@ -1,4 +1,6 @@
+import { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios';
 import { BaseService } from '../core/base.service';
+import { encodeBase64 } from '../../utils';
 import type {
   MerchantAPIKey,
   CreateAPIKeyRequest,
@@ -456,7 +458,7 @@ export class MerchantService extends BaseService {
    * @example
    * ```typescript
    * const result = await MerchantService.distribute({
-   *   user_id: '123',
+  *   user_id: 123,
    *   username: 'alice',
    *   amount: 100,
    *   out_trade_no: 'DIST20251231001',
@@ -466,16 +468,24 @@ export class MerchantService extends BaseService {
    * ```
    * 
    * @remarks
-   * - 使用 POST 请求调用 `/pay/distribute` 接口
+   * - 使用 POST 请求调用 `/pay/distribute` 接口（前端通过 `/lpay/distribute` 代理）
    * - 需要通过 Basic Auth 提供商户凭证
    * - 不能分发给商户自己
    * - 商户余额必须充足
    * - 分发会扣除分发费率（根据商户的支付等级）
    */
   static async distribute(
-    request: MerchantDistributeRequest
+    request: MerchantDistributeRequest,
+    auth?: { client_id: string; client_secret: string }
   ): Promise<MerchantDistributeResponse> {
-    return this.rawPost<MerchantDistributeResponse>('/pay/distribute', request);
+    const config: InternalAxiosRequestConfig | undefined = auth
+      ? {
+          headers: new AxiosHeaders({
+            Authorization: `Basic ${encodeBase64(`${auth.client_id}:${auth.client_secret}`)}`,
+          }),
+        }
+      : undefined;
+    
+    return this.rawPost<MerchantDistributeResponse>('/lpay/distribute', request, config);
   }
 }
-

--- a/frontend/lib/services/merchant/types.ts
+++ b/frontend/lib/services/merchant/types.ts
@@ -334,7 +334,7 @@ export interface RefundMerchantOrderResponse {
  */
 export interface MerchantDistributeRequest {
   /** 接收用户 ID (必填) */
-  user_id: string;
+  user_id: number;
   /** 接收用户名,用于验证 (必填) */
   username: string;
   /** 分发金额 (必填) */

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -37,6 +37,28 @@ export function formatLocalDate(date: Date): string {
   return `${ year }-${ month }-${ day }T${ hours }:${ minutes }:${ seconds }+08:00`
 }
 
+type Base64Buffer = {
+  from: (input: string, encoding: 'utf-8') => { toString: (encoding: 'base64') => string }
+}
+
+/**
+ * Base64 编码
+ * @param value 待编码字符串
+ * @returns Base64 编码后的字符串
+ */
+export function encodeBase64(value: string): string {
+  if (typeof globalThis.btoa === 'function') {
+    return globalThis.btoa(value)
+  }
+
+  const bufferConstructor = (globalThis as typeof globalThis & { Buffer?: Base64Buffer }).Buffer
+  if (bufferConstructor) {
+    return bufferConstructor.from(value, 'utf-8').toString('base64')
+  }
+
+  throw new Error('当前环境不支持 Base64 编码')
+}
+
 /**
  * 生成交易缓存的唯一键
  * @param params 交易查询参数


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**关联信息**

ref: /t/-/1585248

**变更内容**

修复web端积分分发功能404的问题。

**变更原因**

原先积分分发的endpoint使用的是`/pay/distribute`，实际上前端代理的应该是`/lpay/distribute`，另外需要携带authorization header才可以正常分发，此处进行了修正。

修改后，不再显示请求的资源不存在了。

<img width="1392" height="926" alt="image" src="https://github.com/user-attachments/assets/90e6cdea-bd83-4ef1-837f-dfd1aa8bbf8b" />
