### PR TITLE
fix: 主页窄屏修复

### DIFF
--- a/frontend/components/common/home/data-panel.tsx
+++ b/frontend/components/common/home/data-panel.tsx
@@ -180,11 +180,11 @@ export function DataPanel() {
       </div>
 
       {/* 统计数据区域 - 移动端在下方并排展示，桌面端在右侧垂直展示 */}
-      <div className="md:col-span-1 flex flex-row flex-wrap md:flex-col order-2 md:order-none gap-8 md:gap-0 @container">
+      <div className="md:col-span-1 flex flex-row flex-wrap md:flex-col order-2 md:order-none gap-8 md:gap-0">
         <div className="flex-1 min-w-[120px] md:border-b md:pb-4 border-r md:border-r-0 border-border pr-8 md:pr-0">
           <div className="text-sm text-muted-foreground font-medium flex items-center gap-1 whitespace-nowrap">
-            <span className="@[400px]:hidden">可用LDC</span>
-            <span className="hidden @[400px]:inline">可用 LINUX DO Credits</span>
+            <span className="min-[400px]:hidden">可用LDC</span>
+            <span className="hidden min-[400px]:inline">可用 LINUX DO Credits</span>
             <Popover>
               <PopoverTrigger asChild>
                 <button type="button" aria-label="查看详情">


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**关联信息**

https://linux.do/t/topic/1614021

<!-- 若以上均没有，请删除此节 -->

**变更内容**

![image](https://github.com/user-attachments/assets/8e07bd8a-ac9a-4a35-b523-bc92d450903f)


**变更原因**
确保屏幕过窄情况下也能正常显示重要数据