### PR TITLE
fix: banner width adapt to the screen size

### DIFF
--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -132,17 +132,17 @@ function AppBanner() {
           transition={{ duration: 0.3, ease: "easeInOut" }}
           className="relative flex w-full items-center justify-center bg-muted/50 overflow-hidden"
         >
-          <div className="flex w-full items-center justify-center px-4 py-2 text-xs md:text-[13px] font-medium text-muted-foreground">
-            <p>
+          <div className="flex w-full items-center justify-center px-4 pr-10 py-2 text-xs md:text-[13px] font-medium text-muted-foreground">
+            <p className="flex flex-wrap items-center justify-center gap-x-2 text-center">
               <span className="text-foreground">「LINUX DO Credit」实时积分收入脚本已发布</span>
-              <a href="https://linux.do/t/topic/1365853" target="_blank" className="ml-2 underline underline-offset-4 hover:text-foreground">
+              <a href="https://linux.do/t/topic/1365853" target="_blank" className="underline underline-offset-4 hover:text-foreground">
                 查看详情
               </a>
             </p>
             <Button
               variant="ghost"
               size="icon"
-              className="absolute right-2 top-1/2 size-6 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              className="absolute right-2 top-1/2 size-6 -translate-y-1/2 text-muted-foreground hover:text-foreground shrink-0"
               onClick={handleDismiss}
             >
               <span className="sr-only">Dismiss</span>


### PR DESCRIPTION
**例行检查**  

<!-- 请在下面的 [ ] 中删除空格并打 x ，表示已完成相关检查 -->

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md) 
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**关联信息**
/t/-/1614021

**变更内容**

顶部"「LINUX DO Credit」实时积分收入脚本已发布 查看详情" banner适配狭窄屏幕宽度

![屏幕录制 2026-02-14 114813](https://github.com/user-attachments/assets/69da0a3b-19ad-48a4-b1b9-d93c9d8e4bcd)

**变更原因**

之前的banner在较为狭窄的屏幕上，会使得"查看详情"被截断为两行，同时链接会和关闭按钮重叠，导致关闭按钮无法点击：

像这样：
<img width="315" height="48" alt="image" src="https://github.com/user-attachments/assets/29a9fdfd-5ea9-4ebb-8d38-e83954b391fb" />

修改以后就可以适配各种屏幕比例了。