### PR TITLE
fix(redenvelope): prevent negative fixed payouts

### DIFF
--- a/internal/apps/redenvelope/routers.go
+++ b/internal/apps/redenvelope/routers.go
@@ -348,7 +348,7 @@ func Claim(c *gin.Context) {
 			if redEnvelope.RemainingCount == 1 {
 				claimedAmount = redEnvelope.RemainingAmount
 			} else {
-				claimedAmount = redEnvelope.TotalAmount.Div(decimal.NewFromInt(int64(redEnvelope.TotalCount))).Round(2)
+				claimedAmount = redEnvelope.TotalAmount.Div(decimal.NewFromInt(int64(redEnvelope.TotalCount))).Truncate(2)
 			}
 		} else {
 			// 拼手气红包：使用二倍均值算法


### PR DESCRIPTION
**例行检查**

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md)
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**关联信息**

resolves #244

**变更内容**

固定金额红包的单份金额由 `Round(2)` 改为 `Truncate(2)`。最后一位仍拿剩余金额。

**变更原因**

向上取整会让前 N-1 份透支总额。比如 `1.00 LDC / 18`，前 17 份各为 `0.06`，最后一份就成了 `-0.02`。截断后前 17 份各为 `0.05`，最后一份为 `0.15`。

本地已跑过真实 OAuth 浏览器复现、`go test ./...`、后端构建和 Swagger 检查。
