### PR TITLE
fix(docs): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ Thanks to all developers who contributed to this project and the support of the 
 
 ## 📈 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=linux-do/credit&type=Date)](https://star-history.com/#linux-do/credit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=linux-do/credit&type=Date)](https://star-history.dera.page/#linux-do/credit&Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -284,4 +284,4 @@ docker run -d -p 8000:8000 linux-do-credit
 
 ## 📈 项目趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=linux-do/credit&type=Date)](https://star-history.com/#linux-do/credit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=linux-do/credit&type=Date)](https://star-history.dera.page/#linux-do/credit&Date)


### PR DESCRIPTION
The star history chart in README.md and README_zh.md is currently broken and no longer renders because the underlying data source is restricted. This change points the chart to a working service that does not depend on the restricted API, so the project's star growth is visible again.