### PR TITLE
fix(redenvelope): reset daily limit at local midnight

### DIFF
--- a/internal/apps/redenvelope/routers.go
+++ b/internal/apps/redenvelope/routers.go
@@ -150,7 +150,7 @@ func Create(c *gin.Context) {
 
 	// 查询今日已发送的红包数量
 	var todayCount int64
-	today := time.Now().Truncate(24 * time.Hour)
+	today := startOfDay(time.Now())
 	if err := db.DB(c.Request.Context()).Model(&model.RedEnvelope{}).
 		Where("creator_id = ? AND created_at >= ?", currentUser.ID, today).
 		Count(&todayCount).Error; err != nil {

--- a/internal/apps/redenvelope/utils.go
+++ b/internal/apps/redenvelope/utils.go
@@ -18,9 +18,14 @@ package redenvelope
 
 import (
 	"math/rand"
+	"time"
 
 	"github.com/shopspring/decimal"
 )
+
+func startOfDay(now time.Time) time.Time {
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+}
 
 // calculateRandomAmount 二倍均值算法计算随机红包金额
 func calculateRandomAmount(remaining decimal.Decimal, count int) decimal.Decimal {

--- a/internal/apps/redenvelope/utils_test.go
+++ b/internal/apps/redenvelope/utils_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 linux.do
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redenvelope
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStartOfDayUsesLocalMidnight(t *testing.T) {
+	location := time.FixedZone("UTC+8", 8*60*60)
+	now := time.Date(2026, time.September, 4, 1, 30, 0, 0, location)
+	want := time.Date(2026, time.September, 4, 0, 0, 0, 0, location)
+
+	if got := startOfDay(now); !got.Equal(want) {
+		t.Fatalf("startOfDay(%v) = %v, want %v", now, got, want)
+	}
+}


### PR DESCRIPTION
**例行检查**

- [x] 我已阅读并理解 [贡献者公约](https://github.com/linux-do/credit/blob/master/CODE_OF_CONDUCT.md)
- [x] 我已阅读并同意 [贡献者许可协议 (CLA)](https://github.com/linux-do/credit/blob/master/CLA.md)，确认我的贡献将根据项目的 Apache2.0 许可证进行许可
- [x] 我知晓如果此 PR 并不做出实质性更改，或可被认为是*为了PR被合并而提交PR*的，则可能不会被合并

**变更内容**

- 按当前时间所在时区构造当天 00:00，作为每日红包发送数量的查询起点。
- 添加 UTC+8 凌晨场景的回归测试。

**变更原因**

`time.Time.Truncate(24 * time.Hour)` 按绝对时间的 24 小时边界截断，不会返回当前时区的自然日午夜。生产镜像使用 `Asia/Shanghai` 时区，因此原实现会把每日红包数量窗口设为北京时间 08:00 到次日 08:00。

例如在北京时间 2026-09-04 01:30，原实现得到 2026-09-03 08:00，而正确的当天起点应为 2026-09-04 00:00。这会导致用户在 00:00–08:00 期间仍受前一天红包数量影响。

**验证**

- 修复前：`TestStartOfDayUsesLocalMidnight` 失败，实际得到前一天 08:00
- 修复后：专项测试通过
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`
